### PR TITLE
mkdir -p

### DIFF
--- a/base/setup
+++ b/base/setup
@@ -5,7 +5,7 @@ source ${SOURCE_DIR}/config
 
 mkdir -p /etc/circus
 cp ${SOURCE_DIR}/utils/circus.ini /etc/circus/circus.ini
-mkdir /home/application
+mkdir -p /home/application
 useradd -m ${USER} -s /bin/bash
 chown ${USER}:${USER} /home/application
 echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers


### PR DESCRIPTION
It fixes an error which occurs during building a Go Dockerfile

```
Step 8 : run /var/lib/tsuru/base/setup                                                                                                 
 ---> Running in 9a39cf676a96                                                                                                          
mkdir: cannot create directory `/home/application': File exists                  
```
