### PR TITLE
Stop using Distribute (fork of setuptools) as it has been merged back again.

### DIFF
--- a/python3/Dockerfile
+++ b/python3/Dockerfile
@@ -19,5 +19,4 @@ run apt-get update
 run apt-get install python3.4 -y
 run rm /usr/bin/python3
 run ln -s /usr/bin/python3.4 /usr/bin/python3
-run curl http://python-distribute.org/distribute_setup.py | python3
 run curl https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python3


### PR DESCRIPTION
Instead just use pip's get-pip.py which will also automatically install
setuptools if needed:
https://pip.pypa.io/en/latest/installing.html#install-pip
