### PR TITLE
User-fix & Creation of dir /home/application

### DIFF
--- a/cordova/setup
+++ b/cordova/setup
@@ -9,7 +9,7 @@ cp ${SOURCE_DIR}/cordova/etc/circus.ini /etc/circus/circus.ini
 mkdir -p /home/application
 
 # If the user doesn't exist add it
-if [ "$(getent passwd ${USER})" != '' ]; then
+if [ "$(getent passwd ${USER})" == '' ]; then
 	useradd -s /bin/bash -m ${USER};
 fi
 

--- a/static/setup
+++ b/static/setup
@@ -9,7 +9,7 @@ cp ${SOURCE_DIR}/static/etc/circus.ini /etc/circus/circus.ini
 mkdir -p /home/application
 
 # If the user doesn't exist add it
-if [ "$(getent passwd ${USER})" != '' ]; then
+if [ "$(getent passwd ${USER})" == '' ]; then
 	useradd -s /bin/bash -m ${USER};
 fi
 


### PR DESCRIPTION
When adding the platform cordova and static the process quits, because of two reasons that I've fixed here.
1. The user "ubuntu" has already been created
2. You cant do a "mkdir /home/application" on a directory that's already been created

These fixes solves this.
