### PR TITLE
a little more verbosity from lisp deploy

### DIFF
--- a/lisp/deploy
+++ b/lisp/deploy
@@ -47,6 +47,7 @@ if [ -f "${CURRENT_DIR}/requirements.txt" ]; then
 fi
 
 echo "Compiling application...."
-sbcl --non-interactive --eval "(ql:quickload \"${SYSTEM_NAME}\")" &> /dev/null
+sbcl --non-interactive --eval "(ql:quickload \"${SYSTEM_NAME}\")"
 
+echo "Running python hooks...."
 /home/application/.venv/bin/python ${SOURCE_DIR}/hooks.py


### PR DESCRIPTION
Don't hide the output from compiling the application.  If it fails or hangs for whatever reason you get no indication as to why.

I had an application failing to deploy, would just hang at "Compiling application...."
This helped me resolve.
