### PR TITLE
bundle to isolated path

### DIFF
--- a/ruby/deploy
+++ b/ruby/deploy
@@ -5,7 +5,7 @@ source ${SOURCE_DIR}/base/deploy
 source ${SOURCE_DIR}/config
 
 if [ -f ${CURRENT_DIR}/Gemfile ]; then
-	pushd $CURRENT_DIR && sudo bundle install --deployment --without=test development
+	pushd $CURRENT_DIR && bundle install --deployment --path ${CURRENT_DIR}/../vendor/bundle --without=test development
 	popd
 fi
 


### PR DESCRIPTION
This installs vendored gems alongside the application (usually /home/application/vendor/bundle) instead of in the application directory.
Prevents the entire bundle from having to get reinstalled on every deploy (if you use archive-server)
Also removed sudo because you don't need sudo for bundle unless you're installing system gems
