### PR TITLE
deploy: Do pip install in $CURRENT_DIR

### DIFF
--- a/python/deploy
+++ b/python/deploy
@@ -5,10 +5,14 @@ source ${SOURCE_DIR}/base/deploy
 
 source ${SOURCE_DIR}/config
 
-if [ -f ${CURRENT_DIR}/requirements.txt ]; then
-	sudo pip install -r ${CURRENT_DIR}/requirements.txt
-elif [ -f ${CURRENT_DIR}/setup.py ]; then
-	sudo pip install ${CURRENT_DIR}/
-fi
+(
+	cd ${CURRENT_DIR}
+
+	if [ -f ${CURRENT_DIR}/requirements.txt ]; then
+		sudo pip install -r ${CURRENT_DIR}/requirements.txt
+	elif [ -f ${CURRENT_DIR}/setup.py ]; then
+		sudo pip install ${CURRENT_DIR}/
+	fi
+)
 
 /home/application/.venv/bin/python ${SOURCE_DIR}/hooks.py


### PR DESCRIPTION
so "." in `requirements.txt` works

This allows one to have stuff in `requirements.txt` like:

```
-e .
```

Without this, I have to build a new package for my app, which makes it harder to update the app and takes away a lot of convenience of tsuru.
