### PR TITLE
get nodejs from nodesource

### DIFF
--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -5,11 +5,14 @@
 
 from	ubuntu:14.04
 run	apt-get update
-run	DEBIAN_FRONTEND=noninteractive apt-get install wget -y --force-yes
+run	DEBIAN_FRONTEND=noninteractive apt-get install wget curl apt-transport-https -y --force-yes
 run	wget http://github.com/tsuru/basebuilder/tarball/master -O basebuilder.tar.gz --no-check-certificate
 run	mkdir /var/lib/tsuru
 run	tar -xvf basebuilder.tar.gz -C /var/lib/tsuru --strip 1
 run	cp /var/lib/tsuru/nodejs/deploy /var/lib/tsuru
 run	cp /var/lib/tsuru/base/start /var/lib/tsuru
-run	apt-get install npm nodejs nodejs-legacy nodejs-dev -y --force-yes
+run	curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+run	echo 'deb https://deb.nodesource.com/node trusty main' > /etc/apt/sources.list.d/nodesource.list
+run	apt-get update
+run	apt-get install nodejs -y --force-yes
 run	/var/lib/tsuru/base/install

--- a/nodejs/deploy
+++ b/nodejs/deploy
@@ -6,7 +6,7 @@ source ${SOURCE_DIR}/config
 
 if [ -f ${CURRENT_DIR}/package.json ]; then
 	if [ -d ${CURRENT_DIR}/node_modules ]; then rm -rf ${CURRENT_DIR}/node_modules ; fi
-	pushd $CURRENT_DIR && npm install --production --nodedir=/usr/include/nodejs
+	pushd $CURRENT_DIR && npm install --production
 	popd
 fi
 


### PR DESCRIPTION
the nodejs in ubuntu repositories is pretty old.  This installs a newer nodejs package from nodesource that is all inclusive and doesn't need the legacy package or development headers or npm.
