### PR TITLE
Fixes access to apache2 logs

### DIFF
--- a/php/setup
+++ b/php/setup
@@ -16,4 +16,5 @@ END
 > /etc/apache2/ports.conf
 rm -rf /var/log/apache2
 mkdir /var/log/apache2
+touch /var/log/apache2/{access,error}.log
 chown ubuntu:ubuntu -R /var/run/apache2/ /var/log/apache2 /var/lock/apache2


### PR DESCRIPTION
In response to [my comment about access denied on Apache logs](https://github.com/tsuru/basebuilder/pull/9#issuecomment-65401039) in case we're enabling Apache modules on the first push, this PR that fix the problem.
