### PR TITLE
Fixes fpm54 interpretor without extensions

### DIFF
--- a/php/interpretor.py
+++ b/php/interpretor.py
@@ -80,8 +80,10 @@ class FPM54(Interpretor):
 
     def get_packages(self):
         packages = ['php5-common'.join(['', self.phpversion]), 'php5-fpm'.join(['', self.phpversion])]
-        for extension in self.configuration.extensions:
-            packages.append(extension.join(['', self.phpversion]))
+        if 'extensions' in self.configuration:
+            for extension in self.configuration.extensions:
+                packages.append(extension.join(['', self.phpversion]))
+        
         return packages
 
     def post_install(self):


### PR DESCRIPTION
#63 introduced a regression: if there's no extension in the configuration file for interpretor fpm54, then the deployment failed.

This fixes the problem by checking if the `extensions` key is in the configuration.
