### PR TITLE
Fixes PHP55 interpretor

### DIFF
--- a/php/interpretor.py
+++ b/php/interpretor.py
@@ -92,6 +92,9 @@ class FPM55(Interpretor):
     def __init__(self, configuration, application):
         super(FPM55, self).__init__(configuration, application)
 
+    def pre_install(self):
+        pass
+
     def get_packages(self):
         return ['php5-fpm']
 


### PR DESCRIPTION
Since #63, the fpm55 interpretor was broken because there's no `pre_install` method on it.

This PR fixes the issue.
