### PR TITLE
allow custom nginx config

### DIFF
--- a/static/deploy
+++ b/static/deploy
@@ -3,3 +3,5 @@
 SOURCE_DIR=/var/lib/tsuru
 source ${SOURCE_DIR}/base/deploy
 ${VENV_DIR}/bin/python ${SOURCE_DIR}/hooks.py
+APP_DIR=/home/application/current
+test -e ${APP_DIR}/nginx.conf && sudo cp ${APP_DIR}/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
allow custom nginx config for static sites
I used this to set up basic http auth for a static site (grafana)