### PR TITLE
fix silent installation

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -4,7 +4,7 @@
 
 from    ubuntu:14.04
 run	apt-get update
-run	apt-get install wget php5-cli -y --force-yes
+run	apt-get install wget -y --force-yes
 run	mkdir /var/lib/tsuru
 run	wget --no-check-certificate https://github.com/tsuru/basebuilder/tarball/master -O basebuilder.tar.gz
 run	tar -xvf basebuilder.tar.gz -C /var/lib/tsuru --strip 1

--- a/php/deploy.py
+++ b/php/deploy.py
@@ -36,7 +36,7 @@ class Manager(object):
             packages += self.interpretor.get_packages()
 
         print('Installing system packages...')
-        if os.system("apt-get install -y %s" % (' '.join(packages))) != 0:
+        if os.system("apt-get install -y --force-yes %s" % (' '.join(packages))) != 0:
             raise InstallationException('An error appeared while installing needed packages')
 
         # Calling post-install hooks


### PR DESCRIPTION
Since Ubuntu 14.04, `apt-get install -y` must be followed by `--force-yes`.