### PR TITLE
Update nginx.conf

### DIFF
--- a/static/etc/nginx.conf
+++ b/static/etc/nginx.conf
@@ -8,7 +8,8 @@ events {
 http {
 	include      mime.types;
 	default_type application/octet-stream;
-
+	types_hash_max_size 2048; 
+	
 	sendfile     on;
 
 	keepalive_timeout  65;


### PR DESCRIPTION
Add types_hash_max_size to fix types_hash_max_size error on some machines.